### PR TITLE
[backend][frontend] Support account deletion

### DIFF
--- a/frontend/src/components/DeleteAccountModal/index.tsx
+++ b/frontend/src/components/DeleteAccountModal/index.tsx
@@ -1,0 +1,84 @@
+import Dialog from '@material-ui/core/Dialog';
+import DialogTitle from '@material-ui/core/DialogTitle';
+import IconButton from '@material-ui/core/IconButton';
+import Typography from '@material-ui/core/Typography';
+import CloseIcon from '@material-ui/icons/Close';
+import DialogContent from '@material-ui/core/DialogContent';
+import DialogActions from '@material-ui/core/DialogActions';
+import Button from '@material-ui/core/Button';
+import axios from 'axios';
+import React from 'react';
+import { connect } from 'react-redux';
+import { useHistory } from 'react-router-dom';
+import styled from 'styled-components';
+
+const StyledDialogTitle = styled(DialogTitle)`
+  display: inline-flex;
+  align-items: center;
+  background-color: #3f51b5;
+`;
+
+const StyledContrastText = styled(Typography)`
+  color: #ffffff;
+`;
+
+const CloseButton = styled(IconButton)`
+  &.MuiButtonBase-root {
+    position: absolute;
+    color: #ffffff;
+  }
+  right: 5px;
+`;
+
+interface DeleteAccountModalProps {
+  isOpen: boolean;
+  userId: string;
+  handleClose: () => void;
+}
+
+const DeleteAccountModal: React.FC<DeleteAccountModalProps> = ({ isOpen, handleClose, userId }) => {
+  const history = useHistory();
+  const host = window.location.protocol + '//'+ window.location.host;
+
+  const handleDeleteAccount = async () => {
+    try {
+      const response = await axios.delete(`${host}/users/${userId}`);
+      if (response.data.ok === 0) {
+        throw new Error('0 profile deleted');
+      }
+      sessionStorage.clear();
+      history.go(0);
+    } catch (error) {
+      console.error('Error deleting account: ', error);
+    }
+  };
+
+  return (
+    <Dialog open={isOpen} onClose={handleClose}>
+      <StyledDialogTitle disableTypography>
+        <StyledContrastText variant='h4'>Edit Profile</StyledContrastText>
+          <CloseButton onClick={handleClose}>
+            <CloseIcon />
+          </CloseButton>
+      </StyledDialogTitle>
+      <DialogContent dividers>
+        <div>
+          <Typography variant='body1'>
+            Deleting an account is an irreversible action. Once you delete your account, we will not be able to restore you account information. Do you wish to proceed?
+          </Typography>
+        </div>
+        <DialogActions>
+            <Button variant='contained' onClick={handleDeleteAccount}>Yes</Button>
+            <Button color='primary' variant='contained' onClick={handleClose}>No</Button>
+        </DialogActions>
+      </DialogContent>
+    </Dialog>);
+};
+
+const mapStateToProps = (state: any) => {
+  return {
+    userId: state.profile.userId
+  };
+};
+
+export default connect(mapStateToProps)(DeleteAccountModal);

--- a/frontend/src/components/UserInfo/index.tsx
+++ b/frontend/src/components/UserInfo/index.tsx
@@ -4,6 +4,8 @@ import React, { useState } from 'react';
 import { ProfileState } from '../../constants/profileActionTypes';
 import EditProfileModal from '../EditProfileModal';
 import ProfilePhotoDisplay from '../ProfilePhotoDisplay';
+import Button from '@material-ui/core/Button';
+import DeleteAccountModal from '../DeleteAccountModal';
 
 const UserInfoContainer = styled.div`
   flex: 0 1 auto;
@@ -40,15 +42,18 @@ const ActionDiv = styled.div`
 `;
 
 const UserInfo: React.FC<UserInfoProps> = ({ avatar, about, email, booksCount, moviesCount, name/* , openModal */ }) => {
-  const [modalOpen, setModalOpen] = useState(false);
-  const openModal = () => setModalOpen(true);
-  const closeModal = () => setModalOpen(false);
+  const [modalOpen, setModalOpen] = useState({ editProfile: false, deleteAccount: false });
+  const openProfileModal = () => setModalOpen({ ...modalOpen, editProfile: true });
+  const closeProfileModal = () => setModalOpen({ ...modalOpen, editProfile: false });
+  const openDeleteAccountModal = () => setModalOpen({ ...modalOpen, deleteAccount: true });
+  const closeDeleteAccountModal = () => setModalOpen({ ...modalOpen, deleteAccount: false });
   return (
     <UserInfoContainer id='userinfo'>
-        <EditProfileModal isOpen={modalOpen} handleClose={closeModal}/>
+      <EditProfileModal isOpen={modalOpen.editProfile} handleClose={closeProfileModal}/>
+      <DeleteAccountModal isOpen={modalOpen.deleteAccount} handleClose={closeDeleteAccountModal}/>
       <PhotoContainer>
         <ProfilePhotoDisplay avatar={avatar}/>
-        <ActionDiv onClick={openModal}><Typography align='center' color='primary' variant='body1'>Edit Profile</Typography></ActionDiv>
+        <ActionDiv onClick={openProfileModal}><Typography align='center' color='primary' variant='body1'>Edit Profile</Typography></ActionDiv>
       </PhotoContainer>
       <div>
         <Typography variant='body2'>{`User Name: ${name}`}</Typography>
@@ -65,6 +70,7 @@ const UserInfo: React.FC<UserInfoProps> = ({ avatar, about, email, booksCount, m
         <StyledSectionHeader>Contact</StyledSectionHeader>
         <Typography variant='body2'>{email}</Typography>
       </div>
+      <Button variant='contained' onClick={openDeleteAccountModal}>Delete Account</Button>
     </UserInfoContainer>
   );
 };

--- a/frontend/src/containers/Profile/RightSection.tsx
+++ b/frontend/src/containers/Profile/RightSection.tsx
@@ -27,11 +27,11 @@ const RightSection: React.FC<RightSectionProps> = ({ favoriteAuthors, favoriteBo
     <StyledDiv>
       <>
         <SubSectionContainer>
-          <Typography variant='h4'>Favourite Genres</Typography>
+          <Typography variant='h4'>Favourite Genres:</Typography>
           <TagsSection tags={[...favoriteGenres]} singleQueryType={SingleQueryType.genre}/>
         </SubSectionContainer>
         <SubSectionContainer>
-          <Typography variant='h4'>Favourite Tags</Typography>
+          <Typography variant='h4'>Favourite Tags:</Typography>
           <TagsSection tagObjects={[...favoriteNextStoryTags]} singleQueryType={SingleQueryType.tag}/>
         </SubSectionContainer>
         <SubSectionContainer>
@@ -43,10 +43,10 @@ const RightSection: React.FC<RightSectionProps> = ({ favoriteAuthors, favoriteBo
           <TagsSection tags={favoriteDirectors} singleQueryType={SingleQueryType.moviePerson}/>
         </SubSectionContainer>
         <SubSectionContainer>
-          <RegWidthCarousel bookIds={favoriteBooks} bMSource='favorite' movieIds={favoriteMovies} title={`User's Favourite Books/Movies:`} updateMethod={setFavorites}/>
+          <RegWidthCarousel bookIds={favoriteBooks} bMSource='favorite' movieIds={favoriteMovies} title='Favourite Books/Movies:' updateMethod={setFavorites}/>
         </SubSectionContainer>
         <SubSectionContainer>
-          <RegWidthCarousel bMSource='later' title={`User's Read/Watched List`} bookIds={readLater} movieIds={watchLater} withSearchSelect updateMethod={setLater}/>
+          <RegWidthCarousel bMSource='later' title={`User's Read/Watched List`} bookIds={readLater} movieIds={watchLater} updateMethod={setLater}/>
         </SubSectionContainer>
       </>
     </StyledDiv>

--- a/routes/users.js
+++ b/routes/users.js
@@ -1,13 +1,13 @@
 var express = require('express');
 var router = express.Router();
 const Profile = require('../models/profile');
+const ReviewRating = require('../models/reviewRating');
 const bcrypt = require('bcrypt');
 const saltRounds = 10;
 var { uuid } = require('uuidv4');
 
 /* GET users listing. */
 router.get('/:userId', function(req, res, next) {
-    console.log('getting userID');
     const userId = req.params.userId;
     Profile.findOne({ userId : userId }).select('-__v -encrypted')
         .then((user) => {
@@ -18,6 +18,22 @@ router.get('/:userId', function(req, res, next) {
             res.status(500);
         })
 });
+
+/* DELETE user's account */
+router.delete('/:userId', async (req, res) => {
+  const userId = req.params.userId;
+  const result = await Profile.deleteOne({ userId }, (err) => {
+    if (err) {
+      res.status(500).json(err);
+    }
+    ReviewRating.deleteMany({ userId }, (err) => {
+      if (err) {
+        res.status(500).json(err)
+      }
+    })
+  });
+  res.status(200).json(result);
+})
 
 router.get('/favoriteNSTags/:userId', function(req, res, next) {
     const userId = req.params.userId;


### PR DESCRIPTION
This closes #109 : 
- New backend API for deleting an account & associated reviews &
 ratings by userId

 - Frontend UI for deleting account in the Profile page

 - Redux store should have been reset as well. (Profiles & favourites are reset, but I haven't tested reducers for search & filter. Let me know if this is a problem, then I will need to manually reset the everything)